### PR TITLE
fix compiler warnings about unitialized variables

### DIFF
--- a/src/flash/nor/atsamv.c
+++ b/src/flash/nor/atsamv.c
@@ -660,7 +660,7 @@ COMMAND_HANDLER(samv_handle_gpnvm_command)
 			break;
 	}
 
-	uint32_t v;
+	uint32_t v = 0;
 	if (!strcmp("show", CMD_ARGV[0])) {
 		if (who == -1) {
 showall:

--- a/src/flash/nor/numicro.c
+++ b/src/flash/nor/numicro.c
@@ -3326,7 +3326,6 @@ int nulink_usb_M2351_erase(void);
 COMMAND_HANDLER(numicro_handle_M2351_erase_command)
 {
 	int retval = ERROR_OK;
-	uint32_t rdat;
 
 	if (CMD_ARGC != 0)
 		return ERROR_COMMAND_SYNTAX_ERROR;

--- a/src/svf/svf.c
+++ b/src/svf/svf.c
@@ -915,7 +915,7 @@ static int svf_execute_tap(void)
 
 static int svf_run_command(struct command_context *cmd_ctx, char *cmd_str)
 {
-	char *argus[256], command;
+	char *argus[256] = {0}, command;
 	int num_of_argu = 0, i;
 
 	/* tmp variable */

--- a/src/target/hla_target.c
+++ b/src/target/hla_target.c
@@ -266,7 +266,7 @@ static int hl_target_request_data(struct target *target,
 	uint32_t size, uint8_t *buffer)
 {
 	struct hl_interface_s *hl_if = target_to_adapter(target);
-	uint8_t data;
+	uint8_t data = 0;
 	uint8_t ctrl;
 	uint32_t i;
 


### PR DESCRIPTION
Hi. I get some warnings when building with gcc-10.1.0. The warnings go away with the changes in this PR.

```
hla_target.c: In function ‘hl_target_request_data’:
hla_target.c:275:13: error: ‘data’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  275 |   buffer[i] = data;
      |   ~~~~~~~~~~^~~~~~


svf.c: In function ‘svf_run_command’:
svf.c:943:12: error: ‘argus[0]’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  943 |  command = svf_find_string_in_array(argus[0],
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  944 |    (char **)svf_command_name, ARRAY_SIZE(svf_command_name));
      |    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


atsamv.c: In function ‘samv_handle_gpnvm_command’:
atsamv.c:678:4: error: ‘v’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
  678 |    command_print(CMD_CTX, "samv-gpnvm%u: %u", who, v);
      |    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

There is also a fix for an unused variable:

```
numicro.c: In function ‘numicro_handle_M2351_erase_command’:
numicro.c:3329:11: error: unused variable ‘rdat’ [-Werror=unused-variable]
 3329 |  uint32_t rdat = 0;
      |           ^~~~
```