### PR TITLE
fixed compile error: multiple definition of 'bitbang_swd'

### DIFF
--- a/src/jtag/drivers/bitbang.h
+++ b/src/jtag/drivers/bitbang.h
@@ -35,7 +35,7 @@ struct bitbang_interface {
 	void (*swdio_drive)(bool on);
 };
 
-const struct swd_driver bitbang_swd;
+extern const struct swd_driver bitbang_swd;
 
 extern bool swd_mode;
 


### PR DESCRIPTION
When I try to create a package(openocd-nuvoton-git) to the AUR of Arch Linux, I encountered this compilation error on link-time,so I have to fix it.