### PR TITLE
Fix GCC 14 warnings about transposed calloc() arguments

### DIFF
--- a/src/flash/mflash.c
+++ b/src/flash/mflash.c
@@ -1392,7 +1392,7 @@ COMMAND_HANDLER(mg_bank_cmd)
 		return ERROR_FAIL;
 	}
 
-	mflash_bank = calloc(sizeof(struct mflash_bank), 1);
+	mflash_bank = calloc(1, sizeof(struct mflash_bank));
 	COMMAND_PARSE_NUMBER(u32, CMD_ARGV[1], mflash_bank->base);
 	/** @todo Verify how this parsing should work, then document it. */
 	char *str;

--- a/src/flash/nor/ambiqmicro.c
+++ b/src/flash/nor/ambiqmicro.c
@@ -149,7 +149,7 @@ FLASH_BANK_COMMAND_HANDLER(ambiqmicro_flash_bank_command)
 	if (CMD_ARGC < 6)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	ambiqmicro_info = calloc(sizeof(struct ambiqmicro_flash_bank), 1);
+	ambiqmicro_info = calloc(1, sizeof(struct ambiqmicro_flash_bank));
 
 	bank->driver_priv = ambiqmicro_info;
 

--- a/src/flash/nor/stellaris.c
+++ b/src/flash/nor/stellaris.c
@@ -463,7 +463,7 @@ FLASH_BANK_COMMAND_HANDLER(stellaris_flash_bank_command)
 	if (CMD_ARGC < 6)
 		return ERROR_COMMAND_SYNTAX_ERROR;
 
-	stellaris_info = calloc(sizeof(struct stellaris_flash_bank), 1);
+	stellaris_info = calloc(1, sizeof(struct stellaris_flash_bank));
 	bank->base = 0x0;
 	bank->driver_priv = stellaris_info;
 

--- a/src/jtag/drivers/ulink.c
+++ b/src/jtag/drivers/ulink.c
@@ -1521,7 +1521,7 @@ int ulink_queue_scan(struct ulink *device, struct jtag_command *cmd)
 
 	/* Allocate TDO buffer if required */
 	if ((type == SCAN_IN) || (type == SCAN_IO)) {
-		tdo_buffer_start = calloc(sizeof(uint8_t), scan_size_bytes);
+		tdo_buffer_start = calloc(scan_size_bytes, sizeof(uint8_t));
 
 		if (tdo_buffer_start == NULL)
 			return ERROR_FAIL;

--- a/src/target/nds32.c
+++ b/src/target/nds32.c
@@ -395,7 +395,7 @@ static const struct reg_arch_type nds32_reg_access_type_64 = {
 static struct reg_cache *nds32_build_reg_cache(struct target *target,
 		struct nds32 *nds32)
 {
-	struct reg_cache *cache = calloc(sizeof(struct reg_cache), 1);
+	struct reg_cache *cache = calloc(1, sizeof(struct reg_cache));
 	struct reg *reg_list = calloc(TOTAL_REG_NUM, sizeof(struct reg));
 	struct nds32_reg *reg_arch_info = calloc(TOTAL_REG_NUM, sizeof(struct nds32_reg));
 	int i;
@@ -423,7 +423,7 @@ static struct reg_cache *nds32_build_reg_cache(struct target *target,
 		reg_list[i].size = nds32_reg_size(i);
 		reg_list[i].arch_info = &reg_arch_info[i];
 
-		reg_list[i].reg_data_type = calloc(sizeof(struct reg_data_type), 1);
+		reg_list[i].reg_data_type = calloc(1, sizeof(struct reg_data_type));
 
 		if (FD0 <= reg_arch_info[i].num && reg_arch_info[i].num <= FD31) {
 			reg_list[i].value = reg_arch_info[i].value;


### PR DESCRIPTION
GCC 14 implements a coding style warning about the use of calloc() arguments:

```
ulink.c:1524:50: error: 'calloc' sizes specified with 'sizeof' in the
                 earlier argument and not in the later argument
                 [-Werror=calloc-transposed-args]
```

Adapt all flagged uses of calloc().